### PR TITLE
Added ability to specify feature file and line numbers from command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,22 @@ the cucumber features you call grails by one of the following commands:
 
 [grails testtype]: http://ldaley.com/post/615966534/custom-grails-test
 
+# Command-Line Options #
+It is possible to only run specifically tagged scenarios from the command line. For example, if you wanted to run anything tagged with **someTag** then you would use the following command:
+
+    grails test-app :cucumber @someTag
+
+It is also possible to only run a specific feature file from the command line. If you wanted to run the **search** feature file you would use the following command:
+
+    grails test-app :cucumber features/search.feature
+
+The feature file will automatically have the default path (i.e. test/functional) pre-pended to it.
+
+It also possible to specify which line numbers to run within that feature file. If you wanted to run the scenarios on lines 10 and 20 from the **search** feature file then you would
+use the following command:
+
+    grails test-app :cucumber features/search.feature:10:20
+
 # Changes #
 
 see [CHANGES.md](https://github.com/hauner/grails-cucumber/blob/master/CHANGES.md)

--- a/src/groovy/grails/plugin/cucumber/RuntimeOptionsBuilder.groovy
+++ b/src/groovy/grails/plugin/cucumber/RuntimeOptionsBuilder.groovy
@@ -46,16 +46,30 @@ class RuntimeOptionsBuilder {
             return
         }
 
-        options.filters.clear ()
-
+        def filters = []
+        def featurePaths = []
         args.each { arg ->
             switch (arg) {
                 case ~/\w*:cucumber/:
                     break;
                 case ~/~?@.+(:\d)?/:
-                    options.filters << arg
+                    filters << arg
                     break;
+                case ~/.+\.feature(:\d+)*/:
+                    PathWithLines pathWithLines = new PathWithLines(arg)
+                    featurePaths << "$configObject.cucumber.defaultFeaturePath/$pathWithLines.path".toString()
+                    filters += pathWithLines.lines
+                    break
             }
+        }
+
+        if (filters) {
+            options.filters.clear()
+            options.filters.addAll(filters)
+        }
+        if (featurePaths) {
+            options.featurePaths.clear()
+            options.featurePaths.addAll(featurePaths)
         }
     }
 

--- a/test/unit/grails/plugin/cucumber/RuntimeOptionsBuilderSpec.groovy
+++ b/test/unit/grails/plugin/cucumber/RuntimeOptionsBuilderSpec.groovy
@@ -204,7 +204,7 @@ class RuntimeOptionsBuilderSpec extends Specification {
     def "cli filter override config filter" () {
         given:
             configObject.cucumber.tags = TAGS
-            def args = [':cucumber', 'anything']
+            def args = [':cucumber', '@anyTag']
 
         when:
             def options = createRuntimeOptions (configObject, args)
@@ -226,6 +226,81 @@ class RuntimeOptionsBuilderSpec extends Specification {
             options.filters.contains (args[2])
             options.filters.contains (args[3])
             options.filters.contains (args[4])
+    }
+
+    def "adds auto detected feature path from cli" () {
+        given:
+            def path = 'feature/search.feature'
+            def args = [':cucumber', path]
+            configObject.cucumber.defaultFeaturePath = "test/functional"
+
+        when:
+            def options = createRuntimeOptions (configObject, args)
+
+        then:
+            options.filters.size() == 0
+            options.featurePaths.size() == 1
+            options.featurePaths[0] == "$configObject.cucumber.defaultFeaturePath/$path"
+    }
+
+    def "adds auto detected feature path in root directory from cli" () {
+        given:
+            def path = 'search.feature'
+            def args = [':cucumber', path]
+            configObject.cucumber.defaultFeaturePath = "test/functional"
+
+        when:
+            def options = createRuntimeOptions (configObject, args)
+
+        then:
+            options.filters.size() == 0
+            options.featurePaths.size() == 1
+            options.featurePaths[0] == "$configObject.cucumber.defaultFeaturePath/$path"
+    }
+
+    def "adds auto detected feature path two levels down from cli" () {
+        given:
+            def path = 'feature/user/search.feature'
+            def args = [':cucumber', path]
+            configObject.cucumber.defaultFeaturePath = "test/functional"
+
+        when:
+            def options = createRuntimeOptions (configObject, args)
+
+        then:
+            options.filters.size() == 0
+            options.featurePaths.size() == 1
+            options.featurePaths[0] == "$configObject.cucumber.defaultFeaturePath/$path"
+    }
+
+    def "adds auto detected feature path with line number from cli" () {
+        given:
+            def path = 'feature/search.feature:10'
+            def args = [':cucumber', path]
+            configObject.cucumber.defaultFeaturePath = "test/functional"
+
+        when:
+            def options = createRuntimeOptions (configObject, args)
+
+        then:
+            options.filters.size() == 1
+            options.filters[0] == 10
+    }
+
+    def "adds auto detected feature path with multiple line numbers from cli" () {
+        given:
+            def path = 'feature/search.feature:10:20:30'
+            def args = [':cucumber', path]
+            configObject.cucumber.defaultFeaturePath = "test/functional"
+
+        when:
+            def options = createRuntimeOptions (configObject, args)
+
+        then:
+            options.filters.size() == 3
+            options.filters[0] == 10
+            options.filters[1] == 20
+            options.filters[2] == 30
     }
 
     /*


### PR DESCRIPTION
Hi,

I've made a small enhancement to RuntimeOptionsBuilder to allow the specification of which feature file (and optionally line numbers) to run. It seems that this functionality was present in the old addCliFilter(RuntimeOptions) method, but was lost when moving to the new method (I assume because it didn't fit with the style). I've tried to implement it in keeping with how you've done the tags. I've also updated the README to include a section on what can be specified from the command line.

I believe this would allow Issue #11 to be closed.

Example usage:

```
grails test-app :cucumber features/search.feature:10:20
```
