### PR TITLE
Do not compile source folder specified and return early if type is not cucumber

### DIFF
--- a/scripts/_Events.groovy
+++ b/scripts/_Events.groovy
@@ -22,7 +22,11 @@ projectCompiler.configureClasspath()
 
 
 // compile step code given by CucumberConfig:cucumber.sources = [] after anything else was compiled.
-eventTestCompileEnd = {
+eventTestCompileEnd = { type ->
+    if ( !type.contains('cucumber')) {
+        return
+    }
+
     def testType = loadTestType()
 
     List sourceDirs = testType.getGlueSources ()


### PR DESCRIPTION
I encounter a problem when trying to run "test-app unit:" with sources set in CucumberConfig.
I put a check into the event to skip compiling the sources folder if it is not cucumber test
